### PR TITLE
Tiny bug with initialization

### DIFF
--- a/Source/Parser.cs
+++ b/Source/Parser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using UnityEngine;
 
 namespace Tracery
 {
@@ -92,7 +93,9 @@ namespace Tracery
 				Advance();
 			}
 
+		
 			string[] parts = builder.ToString().Split(new char[]{':'}, 2);
+			
 			Assert.AreEqual(parts.Length, 2); // TODO allow function actions
 			string key = parts[0];
 			NodeAction action;

--- a/Source/Unity/GrammarEditor.cs
+++ b/Source/Unity/GrammarEditor.cs
@@ -10,7 +10,7 @@ using Tracery;
 public class GrammarEditor : Editor
 {
 	private int selected = 0;
-	private string testValue = null;
+	private string testValue ="";
 
 	public override void OnInspectorGUI()
 	{
@@ -60,7 +60,7 @@ public class GrammarEditor : Editor
 
 			GUILayout.Space(5);
 
-			if (GUILayout.Button("Test Grammar") || testValue == null)
+			if (GUILayout.Button("Test Grammar")|| testValue==null)
 			{
 				Grammar grammar = ((TraceryGrammar)target).Grammar;
 				testValue = grammar.Flatten("#origin#");

--- a/Source/Unity/TraceryGrammar.cs
+++ b/Source/Unity/TraceryGrammar.cs
@@ -15,7 +15,7 @@ public class TraceryGrammar : MonoBehaviour
 			{
 				grammar.PushRules(s.key, s.rules.Split('\n'));
 			}
-			return grammar;
+				return grammar;
 		}
 	}
 


### PR DESCRIPTION
Fixed a bug where TestGrammar fires on AddComponent
also tested and fully compatible with 2019.4 LTS Unity version.
